### PR TITLE
chore: created typescript-config package

### DIFF
--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -1,0 +1,73 @@
+# @repo/typescript-config
+
+Centralized TypeScript configurations for the memshelf monorepo.
+
+## Architecture
+
+This package provides a hierarchical TypeScript configuration system:
+
+```
+tsconfig.json (base)
+├── tsconfig.apps.json (base + app-specific)
+└── tsconfig.packages.json (base + package-specific)
+    └── tsconfig.decorators.json (packages + decorator support)
+```
+
+## Configurations
+
+### `tsconfig.json` (Base)
+Core TypeScript settings shared across all projects:
+- ESNext target with bundler module resolution
+- Strict mode enabled
+- Modern JavaScript features
+
+### `tsconfig.apps.json`
+Extends decorators configuration for applications:
+- Apps need decorator support to use database packages
+- Build output configured per app
+
+### `tsconfig.packages.json`
+Minimal extension of base configuration for internal packages:
+- No build outputs - packages remain as TypeScript source
+- Source-first architecture support
+
+### `tsconfig.decorators.json` 
+Extends packages configuration for decorator-using packages:
+- Experimental decorators enabled
+- Decorator metadata emission
+- Relaxed property initialization for TypeORM entities
+
+## Usage
+
+### For Apps (CLI, Web)
+```json
+{
+  "extends": "@repo/typescript-config/tsconfig.apps.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}
+```
+
+### For Regular Packages (shared-core, shared-services)
+```json
+{
+  "extends": "@repo/typescript-config/tsconfig.packages.json"
+}
+```
+
+### For Decorator Packages (database, queues)
+```json
+{
+  "extends": "@repo/typescript-config/tsconfig.decorators.json"
+}
+```
+
+## Source-First Architecture
+
+This configuration supports a source-first monorepo where:
+- Internal packages remain as TypeScript source during development
+- Apps bundle all dependencies from source at build time
+- No intermediate build steps required for package changes
+- Better debugging and development experience

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@repo/typescript-config",
+    "version": "0.0.0",
+    "private": true,
+    "license": "MIT",
+    "description": "Shared TypeScript configurations for the monorepo",
+    "files": [
+        "tsconfig.json",
+        "tsconfig.apps.json",
+        "tsconfig.packages.json",
+        "tsconfig.decorators.json"
+    ],
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/typescript-config/tsconfig.apps.json
+++ b/packages/typescript-config/tsconfig.apps.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.decorators.json",
+    "compilerOptions": {
+        // Apps are end consumers, not dependencies
+        "composite": false,
+        "declaration": false,
+        "declarationMap": false
+    }
+}

--- a/packages/typescript-config/tsconfig.decorators.json
+++ b/packages/typescript-config/tsconfig.decorators.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.packages.json",
+    "compilerOptions": {
+        // Decorator support for packages that need it (database, etc.)
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false
+    }
+}

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        // Environment setup & latest features
+        "lib": ["ESNext"],
+        "target": "ESNext",
+        "module": "Preserve",
+        "moduleDetection": "force",
+
+        // Bundler mode
+        "moduleResolution": "bundler",
+        "verbatimModuleSyntax": true,
+
+        // Best practices
+        "strict": true,
+        "skipLibCheck": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedIndexedAccess": true,
+        "noImplicitOverride": true,
+
+        // Some stricter flags
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noPropertyAccessFromIndexSignature": false
+    }
+}

--- a/packages/typescript-config/tsconfig.packages.json
+++ b/packages/typescript-config/tsconfig.packages.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "declaration": true,
+        "declarationMap": true
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a new typescript-config package to centralize TypeScript configurations across the monorepo

Enhancements:
- Provide a hierarchical set of tsconfig files (base, apps, packages, decorators) for shared compiler settings

Documentation:
- Add README detailing the architecture, configurations, and usage of the typescript-config package

Chores:
- Scaffold the @repo/typescript-config package with package.json and tsconfig files