### PR TITLE
Refactor/db package refactor

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -16,11 +16,12 @@
         "migration:revert": "bun --bun typeorm migration:revert -d src/dataSource.ts"
     },
     "dependencies": {
-        "mysql2": "^3.12.0",
         "@repo/shared-core": "*",
-        "typeorm-inflection-naming-strategy": "*",
+        "mysql2": "^3.12.0",
         "tsyringe": "^4.10.0",
         "typeorm": "^0.3.25",
+        "typeorm-inflection-naming-strategy": "*",
+        "typeorm-pino-logger": "^0.1.0",
         "zod": "^3.25.76"
     },
     "devDependencies": {

--- a/packages/database/src/config.ts
+++ b/packages/database/src/config.ts
@@ -1,23 +1,27 @@
-import type { RepoConfig } from '@repo/shared-core';
+import { createBaseLogger, type RepoConfig } from '@repo/shared-core';
 import { DataSource, type DataSourceOptions } from 'typeorm';
 import { InflectionNamingStrategy } from 'typeorm-inflection-naming-strategy/src';
+import { TypeOrmPinoLogger } from 'typeorm-pino-logger';
 import { AppDataSource } from './dataSource';
 
 /**
  * Merge package default config with app-specific overrides
  */
 export function createDataSourceOptions(repoConfig: RepoConfig): DataSourceOptions {
+    const typeormLogger = new TypeOrmPinoLogger(createBaseLogger(repoConfig));
+
     return {
         type: 'mysql',
         ...repoConfig.database,
-        synchronize: false,
-        migrationsRun: false,
-        entities: [`${__dirname}/entities/*.ts`],
-        migrations: ['src/migrations/*.ts'],
-        migrationsTableName: 'typeorm_migrations',
-        namingStrategy: new InflectionNamingStrategy(),
         charset: 'utf8mb4',
         timezone: 'Z',
+        synchronize: false,
+        entities: [`${__dirname}/entities/*Entity.{ts,js}`],
+        migrations: [`${__dirname}/migrations/*.{ts,js}`],
+        migrationsTableName: 'typeorm_migrations',
+        migrationsRun: true,
+        namingStrategy: new InflectionNamingStrategy(),
+        logger: typeormLogger,
     };
 }
 

--- a/packages/database/src/core/DbServiceInterface.ts
+++ b/packages/database/src/core/DbServiceInterface.ts
@@ -22,7 +22,9 @@ export interface DbServiceInterface<T extends AppEntity> {
 
     remove(id: number | string): Promise<void>;
 
-    upsert(entity: QueryDeepPartialEntity<T>, conflictPathsOrOptions: string[]): Promise<T>;
+    upsert(entity: QueryDeepPartialEntity<T>, conflictPathsOrOptions: string[]): Promise<void>;
+
+    upsertAndReload(entity: QueryDeepPartialEntity<T>, conflictPathsOrOptions: string[]): Promise<T>;
 
     softDelete(id: number | string): Promise<void>;
 

--- a/packages/database/src/services/UsersDbService.ts
+++ b/packages/database/src/services/UsersDbService.ts
@@ -1,0 +1,11 @@
+import { inject, singleton } from 'tsyringe';
+import { DataSource } from 'typeorm';
+import { BaseDbService } from '../core/BaseDbService';
+import { UserEntity } from '../entities';
+
+@singleton()
+export class UsersDbService extends BaseDbService<UserEntity> {
+    constructor(@inject(DataSource) dataSource: DataSource) {
+        super(dataSource.getRepository(UserEntity));
+    }
+}

--- a/packages/database/src/services/index.ts
+++ b/packages/database/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './UsersDbService';


### PR DESCRIPTION
## Summary by Sourcery

Refactor the database package by renaming the base service, splitting and enhancing the upsert workflow, improving TypeORM configuration with logging and migration settings, and adding a new user service implementation.

New Features:
- Add upsertAndReload method for reloading entities after upsert
- Introduce UsersDbService for user-specific database operations

Enhancements:
- Rename BaseService to BaseDbService and update upsert signature to void
- Extend DbServiceInterface with upsertAndReload
- Integrate Pino-based logger into TypeORM configuration and enable automatic migrations
- Refine entity and migration file patterns, charset, and timezone settings in data source options

Build:
- Add typeorm-pino-logger dependency to package.json